### PR TITLE
Show runner exceptions

### DIFF
--- a/lib/test_notifier/runner/autotest.rb
+++ b/lib/test_notifier/runner/autotest.rb
@@ -29,6 +29,8 @@ Autotest.add_hook :ran_command do |at|
 
       TestNotifier.notify(:status => stats.status, :message => stats.message) unless tests.to_i.zero?
     end
-  rescue
+  rescue => e
+    puts e
+    puts e.backtrace
   end
 end

--- a/lib/test_notifier/runner/test_unit.rb
+++ b/lib/test_notifier/runner/test_unit.rb
@@ -21,7 +21,9 @@ class Test::Unit::UI::Console::TestRunner
       })
 
       TestNotifier.notify(:status => stats.status, :message => stats.message)
-    rescue
+    rescue => e
+      puts e
+      puts e.backtrace
     end
   end
 end


### PR DESCRIPTION
I've spent quite amount of time for finding out why my autotest notifications weren't working - all because exceptions were silenced.

For them being silenced i had to debug and try to find out if the problem was in my installation of Snarl or in autotest or it's configuration or ruby-snarl and so on.

Is there any good reason why they should be silenced? Maybe i cannot see the big picture...
