### PR TITLE
MiniTest Runner - Errors are not reported

### DIFF
--- a/lib/test_notifier/runner/minitest.rb
+++ b/lib/test_notifier/runner/minitest.rb
@@ -8,7 +8,7 @@ MiniTest::Unit.after_tests do
     :count      => runner.test_count,
     :assertions => runner.assertion_count,
     :failures   => runner.failures,
-    :errors     => runner.skips
+    :errors     => runner.errors
   })
 
   TestNotifier.notify(:status => stats.status, :message => stats.message)


### PR DESCRIPTION
I am running Test_Notifier 1.0.0 with MiniTest 2.11.1 and noticed that errors are not reported in the notification.

Attached is a fix that worked for me
