### PR TITLE
Use runner.errors for MiniTest

### DIFF
--- a/lib/test_notifier/runner/minitest.rb
+++ b/lib/test_notifier/runner/minitest.rb
@@ -8,7 +8,7 @@ MiniTest::Unit.after_tests do
     :count      => runner.test_count,
     :assertions => runner.assertion_count,
     :failures   => runner.failures,
-    :errors     => runner.skips
+    :errors     => runner.errors
   })
 
   TestNotifier.notify(:status => stats.status, :message => stats.message)


### PR DESCRIPTION
This pull request fixes a bug I accidentally introduced when writing the MiniTest runner. Rather than using `runner.errors` to I used `runner.skips` which is incorrect.

Sorry about that :flushed:
